### PR TITLE
Fix: Add bulldozer and excavator yamls to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,5 @@ pnpm-lock.yaml
 package-lock.json
 yarn.lock
 .github
+.bulldozer.yml
+.excavator.yml


### PR DESCRIPTION
## Before this PR
Autogenerated .bulldozer.yml and .excavator.yml would cause prettier formatting to fail due to double quotes.

## After this PR
These files are now ignored.

==COMMIT_MSG==
Fix: Add bulldozer and excavator yamls to prettierignore
==COMMIT_MSG==
