### PR TITLE
fix: add shell: true for Windows npx spawn compatibility

### DIFF
--- a/src/__tests__/spawn.test.ts
+++ b/src/__tests__/spawn.test.ts
@@ -40,6 +40,7 @@ describe('spawn', () => {
         ['-y', '@palantir/mcp@latest', '--help', '--verbose'],
         expect.objectContaining({
           stdio: 'inherit',
+          shell: true,
         }),
       )
     })

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -17,6 +17,7 @@ export function spawnMcp({ npmRegistry, foundryToken, args }: SpawnOptions): voi
 
   const child = spawn('npx', ['-y', '@palantir/mcp@latest', ...args], {
     stdio: 'inherit',
+    shell: true, // Required for Windows: npx resolves to npx.cmd
     env: {
       ...process.env,
       NPM_CONFIG_REGISTRY: npmRegistry.toString(),


### PR DESCRIPTION
## Summary
Fixes #23

On Windows, \
px\ resolves to \
px.cmd\ and Node.js \child_process.spawn()\ cannot find it without \shell: true\. This causes the \spawn npx ENOENT\ error when running palantir-mcp on Windows.

## Changes
- Added \shell: true\ to spawn options in \src/spawn.ts\
- Updated spawn test to assert the \shell\ option is passed

## Testing
- \
pm run typecheck\ ✓
- \
pm run lint\ ✓
- Verified fix on Windows 11

