### PR TITLE
Fix: Bump node to have npm 11.5.1 required for trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node-executor:
     docker:
-      - image: cimg/node:22.14
+      - image: cimg/node:22.22
     resource_class: medium
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,9 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Upgrade npm for trusted publishing
+          command: npm install -g npm@latest
+      - run:
           name: Set version from git tag
           command: |
             if [ -z "$CIRCLE_TAG" ]; then


### PR DESCRIPTION
before 
```
circleci@6ffdd29f3207:~$ npm --version
10.9.2
circleci@6ffdd29f3207:~$ node --version
v22.14.0
```

npm version we need is 11.5.1 but it does not ship with node 22. It does ship with node 24 but it's not LTS yet 