### PR TITLE
fix: cross-platform npm build and package version e2e on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "tsx src/index.ts",
     "clean": "rimraf dist",
     "bundle": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --platform=node --target=node18 --sourcemap --external:@osdk/* --external:commander",
-    "build": "npm run clean && npm run bundle && chmod +x dist/index.js",
+    "build": "npm run clean && npm run bundle && node scripts/make-executable.mjs",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint . --ext .ts",

--- a/scripts/make-executable.mjs
+++ b/scripts/make-executable.mjs
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Palantir Technologies
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root.
+ */
+
+import { chmodSync } from 'fs'
+
+if (process.platform !== 'win32') {
+  chmodSync('dist/index.js', 0o755)
+}

--- a/src/__tests__/packageInfoUtils.e2e.test.ts
+++ b/src/__tests__/packageInfoUtils.e2e.test.ts
@@ -25,8 +25,16 @@
  */
 
 import { execSync } from 'child_process'
-import { existsSync, unlinkSync } from 'fs'
+import { copyFileSync, existsSync, unlinkSync } from 'fs'
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+
+function restoreFromBackup(backupPath: string, targetPath: string): void {
+  if (!existsSync(backupPath)) {
+    return
+  }
+  copyFileSync(backupPath, targetPath)
+  unlinkSync(backupPath)
+}
 
 describe('Package Version E2E', () => {
   const testVersion = '12.34.56-e2e-test'
@@ -34,9 +42,9 @@ describe('Package Version E2E', () => {
 
   beforeAll(() => {
     // Save original package.json and package-lock.json in backup files, so we can revert after the test completes
-    execSync('cp package.json package.json.backup', { stdio: 'pipe' })
+    copyFileSync('package.json', 'package.json.backup')
     if (existsSync('package-lock.json')) {
-      execSync('cp package-lock.json package-lock.json.backup', { stdio: 'pipe' })
+      copyFileSync('package-lock.json', 'package-lock.json.backup')
     }
 
     // Set test version
@@ -59,13 +67,11 @@ describe('Package Version E2E', () => {
     }
 
     // Restore original package.json
-    if (existsSync('package.json.backup')) {
-      execSync('mv package.json.backup package.json', { stdio: 'pipe' })
-    }
+    restoreFromBackup('package.json.backup', 'package.json')
 
     // Restore original package-lock.json if it was backed up
     if (existsSync('package-lock.json.backup')) {
-      execSync('mv package-lock.json.backup package-lock.json', { stdio: 'pipe' })
+      restoreFromBackup('package-lock.json.backup', 'package-lock.json')
     } else if (existsSync('package-lock.json')) {
       // Remove package-lock.json if it didn't exist originally
       unlinkSync('package-lock.json')


### PR DESCRIPTION
## Summary
Replace Unix-only \chmod\ / \cp\ / \mv\ in the build script and package version E2E so contributors on Windows get a green \
pm test\ / \
pm run build\.

## Changes
- **Build:** \chmod +x dist/index.js\ -> \
ode scripts/make-executable.mjs\ (no-op on win32, \chmodSync\ elsewhere)
- **E2E:** backup/restore \package.json\ (and lockfile) via \s.copyFileSync\ instead of shell \cp\ / \mv\

## Test plan
- \
pm test\
- \
pm run build\
