### PR TITLE
feat(spawn): optional PALANTIR_MCP_PACKAGE to pin @palantir/mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,29 @@ claude mcp add palantir-mcp \
 }
 ```
 
+## Pinning `@palantir/mcp` (workaround)
+
+Some strict MCP clients reject tool schemas if a published `@palantir/mcp` build declares an `array` parameter without `items` (see [palantir/palantir-mcp#31](https://github.com/palantir/palantir-mcp/issues/31)). Until Palantir ships a fix in `@palantir/mcp`, you can **pin** the package version the wrapper installs by setting:
+
+```bash
+export PALANTIR_MCP_PACKAGE=@palantir/mcp@0.305.0
+```
+
+Then run `npx palantir-mcp ...` as usual. The value **must** start with `@palantir/mcp@` followed by a version tag (for example `latest` or `0.305.0`).
+
+In **Cursor** / **VS Code** MCP config, add the same variable alongside `FOUNDRY_TOKEN`:
+
+```json
+"env": {
+  "FOUNDRY_TOKEN": "<token>",
+  "PALANTIR_MCP_PACKAGE": "@palantir/mcp@0.305.0"
+}
+```
+
+Adjust the version to whatever your Foundry registry documents as a known-good release.
+
+**Note:** Correct URL construction for `clone_code_repository_locally` (email / git userinfo) and ontology `objectTypeId` validation are implemented inside **`@palantir/mcp`**, not this wrapper — track [palantir/palantir-mcp#24](https://github.com/palantir/palantir-mcp/issues/24) and [#19](https://github.com/palantir/palantir-mcp/issues/19).
+
 ## Development
 
 ```bash
@@ -158,7 +181,7 @@ npm run format
 The tool is organized into focused modules:
 
 - `cli.ts` - Command-line argument parsing and validation
-- `spawn.ts` - Process spawning and signal handling
+- `spawn.ts` - Process spawning, optional `PALANTIR_MCP_PACKAGE` override for pinning `@palantir/mcp`
 - `registry.ts` - NPM registry URL construction
 - `errors.ts` - Custom error classes for better error handling
 - `preflightChecks.ts` - Validation of environment and credentials

--- a/src/__tests__/spawn.test.ts
+++ b/src/__tests__/spawn.test.ts
@@ -7,7 +7,7 @@
 import { spawn } from 'child_process'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { spawnMcp } from '../spawn.js'
+import { resolvePalantirMcpPackageSpec, spawnMcp } from '../spawn.js'
 
 vi.mock('child_process', () => ({
   spawn: vi.fn(),
@@ -18,6 +18,7 @@ describe('spawn', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    delete process.env.PALANTIR_MCP_PACKAGE
   })
 
   describe('spawnMcp', () => {
@@ -131,6 +132,41 @@ describe('spawn', () => {
       spawnMcp(options)
 
       expect(process.listenerCount('SIGTERM')).toBe(originalListenerCount + 1)
+    })
+
+    it('should use PALANTIR_MCP_PACKAGE when set for pin workaround', () => {
+      const mockChild = { kill: vi.fn() }
+      mockSpawn.mockReturnValue(mockChild)
+      process.env.PALANTIR_MCP_PACKAGE = '@palantir/mcp@0.305.0'
+
+      spawnMcp({
+        npmRegistry: new URL('https://example.com/npm/'),
+        foundryToken: 'test-token',
+        args: [],
+      })
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'npx',
+        ['-y', '@palantir/mcp@0.305.0'],
+        expect.anything(),
+      )
+    })
+  })
+
+  describe('resolvePalantirMcpPackageSpec', () => {
+    it('defaults to @palantir/mcp@latest', () => {
+      delete process.env.PALANTIR_MCP_PACKAGE
+      expect(resolvePalantirMcpPackageSpec()).toBe('@palantir/mcp@latest')
+    })
+
+    it('accepts pinned Palantir MCP version', () => {
+      process.env.PALANTIR_MCP_PACKAGE = '@palantir/mcp@0.305.0'
+      expect(resolvePalantirMcpPackageSpec()).toBe('@palantir/mcp@0.305.0')
+    })
+
+    it('rejects non-palantir package prefix', () => {
+      process.env.PALANTIR_MCP_PACKAGE = 'evil@1.0.0'
+      expect(() => resolvePalantirMcpPackageSpec()).toThrow(/must start with @palantir\/mcp@/)
     })
   })
 })

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -12,11 +12,34 @@ export interface SpawnOptions {
   args: string[]
 }
 
+const PALANTIR_MCP_PREFIX = '@palantir/mcp@'
+
+/** Resolved package spec for npx (default @palantir/mcp@latest). Exposed for tests. */
+export function resolvePalantirMcpPackageSpec(): string {
+  const override = process.env.PALANTIR_MCP_PACKAGE?.trim()
+  if (!override) {
+    return `${PALANTIR_MCP_PREFIX}latest`
+  }
+  if (!override.startsWith(PALANTIR_MCP_PREFIX)) {
+    throw new Error(
+      `PALANTIR_MCP_PACKAGE must start with ${PALANTIR_MCP_PREFIX} (e.g. ${PALANTIR_MCP_PREFIX}0.305.0)`,
+    )
+  }
+  const version = override.slice(PALANTIR_MCP_PREFIX.length)
+  if (!version || !/^[\w.+-]+$/.test(version)) {
+    throw new Error(
+      `PALANTIR_MCP_PACKAGE version segment after ${PALANTIR_MCP_PREFIX} must be non-empty and npm-version-safe`,
+    )
+  }
+  return override
+}
+
 export function spawnMcp({ npmRegistry, foundryToken, args }: SpawnOptions): void {
   const authTokenEnvVar = `NPM_CONFIG_//${npmRegistry.host + npmRegistry.pathname}:_authToken`
+  const packageSpec = resolvePalantirMcpPackageSpec()
 
   const isWindows = process.platform === 'win32'
-  const child = spawn('npx', ['-y', '@palantir/mcp@latest', ...args], {
+  const child = spawn('npx', ['-y', packageSpec, ...args], {
     stdio: 'inherit',
     shell: isWindows,
     env: {


### PR DESCRIPTION
## Summary
Allow pinning the resolved \@palantir/mcp\ version via env var \PALANTIR_MCP_PACKAGE\ (must be \@palantir/mcp@<tag>\), defaulting to \@palantir/mcp@latest\.

## Motivation
Mitigates strict MCP hosts (e.g. VS Code) when a published \@palantir/mcp\ build exposes invalid JSON Schema (array without \items\). See #31.

## Usage
\\\ash
export PALANTIR_MCP_PACKAGE=@palantir/mcp@0.305.0
npx palantir-mcp --foundry-api-url https://<host> ...
\\\

Cursor / VS Code: add \PALANTIR_MCP_PACKAGE\ next to \FOUNDRY_TOKEN\ in MCP \env\ (see README).

## Test plan
- \
pm test\
- \
pm run typecheck\

Related: #31
