### PR TITLE
Use provided token if cached token has expired

### DIFF
--- a/src/__tests__/preflightChecks.test.ts
+++ b/src/__tests__/preflightChecks.test.ts
@@ -44,20 +44,22 @@ describe('preflightChecks', () => {
   const foundryToken = 'test-token'
   const npmRegistry = new URL('https://example.palantirfoundry.com/npm/')
 
-  let mockRefreshTokenIfExpired: ReturnType<typeof vi.fn>
+  // Mocks receive the token the TokenRefreshUtils was constructed with, so tests
+  // can drive per-token behaviour (e.g. cached expired, CLI valid).
+  let mockIsExpired: ReturnType<typeof vi.fn>
   let mockForceRefreshToken: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     vi.clearAllMocks()
     global.fetch = vi.fn()
 
-    mockRefreshTokenIfExpired = vi.fn()
+    mockIsExpired = vi.fn().mockResolvedValue(false)
     mockForceRefreshToken = vi.fn()
     vi.mocked(TokenRefreshUtils).mockImplementation(
-      () =>
+      (_apiUrl: URL, token: string) =>
         ({
-          refreshTokenIfExpired: mockRefreshTokenIfExpired,
-          forceRefreshToken: mockForceRefreshToken,
+          isExpired: () => mockIsExpired(token),
+          forceRefreshToken: () => mockForceRefreshToken(token),
         }) as unknown as TokenRefreshUtils,
     )
     vi.mocked(tokenCache.loadCachedToken).mockReturnValue(undefined)
@@ -73,7 +75,7 @@ describe('preflightChecks', () => {
       }
 
       vi.mocked(tokenCache.loadCachedToken).mockReturnValue(CACHED_TOKEN)
-      mockRefreshTokenIfExpired.mockResolvedValue(undefined) // token still valid
+      mockIsExpired.mockResolvedValue(false) // token still valid
       ;(global.fetch as any).mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({ ok: true })
 
       expect(() => checkNodeVersion()).not.toThrow()
@@ -118,48 +120,68 @@ describe('preflightChecks', () => {
   })
 
   describe('validateFoundryToken', () => {
-    it('should return cached token when it is still valid', async () => {
+    it('should return the cached token when it is still valid', async () => {
       vi.mocked(tokenCache.loadCachedToken).mockReturnValue(CACHED_TOKEN)
-      mockRefreshTokenIfExpired.mockResolvedValue(undefined)
+      mockIsExpired.mockResolvedValue(false)
 
       const result = await validateFoundryToken(foundryApiUrl, CLI_TOKEN)
 
       expect(result).toBe(CACHED_TOKEN)
+      expect(mockForceRefreshToken).not.toHaveBeenCalled()
     })
 
-    it('should return refreshed token when cached token is expired', async () => {
+    it('should prefer a valid CLI/env token over an expired cached token without opening a browser', async () => {
       vi.mocked(tokenCache.loadCachedToken).mockReturnValue(CACHED_TOKEN)
-      mockRefreshTokenIfExpired.mockResolvedValue(REFRESHED_TOKEN)
-
-      const result = await validateFoundryToken(foundryApiUrl, CLI_TOKEN)
-
-      expect(result).toBe(REFRESHED_TOKEN)
-    })
-
-    it('should fall back to CLI token when cached token is invalid', async () => {
-      vi.mocked(tokenCache.loadCachedToken).mockReturnValue(CACHED_TOKEN)
-      mockRefreshTokenIfExpired
-        .mockRejectedValueOnce(new InvalidAuthTokenError(foundryApiUrl.hostname))
-        .mockResolvedValueOnce(undefined) // CLI token is valid
+      // Cached token is expired; the explicitly provided CLI/env token is valid.
+      mockIsExpired.mockImplementation(async (token: string) => token === CACHED_TOKEN)
 
       const result = await validateFoundryToken(foundryApiUrl, CLI_TOKEN)
 
       expect(result).toBe(CLI_TOKEN)
-      expect(TokenRefreshUtils).toHaveBeenCalledTimes(2)
+      // The valid provided token must win with no interactive browser flow.
+      expect(mockForceRefreshToken).not.toHaveBeenCalled()
     })
 
-    it('should throw when all tokens are invalid', async () => {
+    it('should interactively refresh the cached token when no token is currently valid', async () => {
       vi.mocked(tokenCache.loadCachedToken).mockReturnValue(CACHED_TOKEN)
-      mockRefreshTokenIfExpired.mockRejectedValue(new InvalidAuthTokenError(foundryApiUrl.hostname))
+      mockIsExpired.mockResolvedValue(true) // both cached and CLI expired
+      mockForceRefreshToken.mockResolvedValue(REFRESHED_TOKEN)
+
+      const result = await validateFoundryToken(foundryApiUrl, CLI_TOKEN)
+
+      expect(result).toBe(REFRESHED_TOKEN)
+      // Cached token is refreshed first.
+      expect(mockForceRefreshToken).toHaveBeenCalledWith(CACHED_TOKEN)
+    })
+
+    it('should skip a cached token that is invalid for this stack and use a valid CLI token', async () => {
+      vi.mocked(tokenCache.loadCachedToken).mockReturnValue(CACHED_TOKEN)
+      mockIsExpired.mockImplementation(async (token: string) => {
+        if (token === CACHED_TOKEN) {
+          throw new InvalidAuthTokenError(foundryApiUrl.hostname)
+        }
+        return false // CLI token is valid
+      })
+
+      const result = await validateFoundryToken(foundryApiUrl, CLI_TOKEN)
+
+      expect(result).toBe(CLI_TOKEN)
+      expect(mockForceRefreshToken).not.toHaveBeenCalled()
+    })
+
+    it('should throw when every token is invalid for this stack', async () => {
+      vi.mocked(tokenCache.loadCachedToken).mockReturnValue(CACHED_TOKEN)
+      mockIsExpired.mockRejectedValue(new InvalidAuthTokenError(foundryApiUrl.hostname))
 
       await expect(validateFoundryToken(foundryApiUrl, CLI_TOKEN)).rejects.toThrow(
         NoTokenAvailableError,
       )
+      expect(mockForceRefreshToken).not.toHaveBeenCalled()
     })
 
     it('should deduplicate when cached and CLI tokens are identical', async () => {
       vi.mocked(tokenCache.loadCachedToken).mockReturnValue(CLI_TOKEN)
-      mockRefreshTokenIfExpired.mockResolvedValue(undefined)
+      mockIsExpired.mockResolvedValue(false)
 
       const result = await validateFoundryToken(foundryApiUrl, CLI_TOKEN)
 
@@ -168,7 +190,7 @@ describe('preflightChecks', () => {
       expect(TokenRefreshUtils).toHaveBeenCalledTimes(1)
     })
 
-    it('should use git token only for browser auth bootstrap via forceRefreshToken', async () => {
+    it('should use the git token only for browser auth bootstrap via forceRefreshToken', async () => {
       // No cached or CLI token — only git token available
       vi.mocked(gitConfigParser.parseGitToken).mockReturnValue('git-token')
       mockForceRefreshToken.mockResolvedValue(REFRESHED_TOKEN)
@@ -176,9 +198,9 @@ describe('preflightChecks', () => {
       const result = await validateFoundryToken(foundryApiUrl, undefined)
 
       expect(result).toBe(REFRESHED_TOKEN)
-      // Should use forceRefreshToken (not refreshTokenIfExpired) for git tokens
-      expect(mockForceRefreshToken).toHaveBeenCalledTimes(1)
-      expect(mockRefreshTokenIfExpired).not.toHaveBeenCalled()
+      expect(mockForceRefreshToken).toHaveBeenCalledWith('git-token')
+      // isExpired is never consulted for the git bootstrap path.
+      expect(mockIsExpired).not.toHaveBeenCalled()
     })
 
     it('should throw when git token force refresh fails', async () => {

--- a/src/preflightChecks.ts
+++ b/src/preflightChecks.ts
@@ -35,23 +35,6 @@ export async function checkNetworkConnectivity(foundryApiUrl: URL): Promise<void
 }
 
 /**
- * Tries to validate/refresh a single token via Multipass TTL check.
- * Returns the token (or a refreshed replacement) on success, undefined on failure.
- */
-async function tryRefreshToken(foundryApiUrl: URL, token: string): Promise<string | undefined> {
-  try {
-    const newToken = await new TokenRefreshUtils(foundryApiUrl, token).refreshTokenIfExpired()
-    return newToken ?? token
-  } catch (error: unknown) {
-    if (error instanceof InvalidAuthTokenError) {
-      console.error(error.message)
-      return undefined
-    }
-    throw error
-  }
-}
-
-/**
  * Git token has very limited scope — only useful to bootstrap browser auth.
  */
 async function bootstrapTokenFromGitConfig(foundryApiUrl: URL): Promise<string | undefined> {
@@ -67,29 +50,54 @@ async function bootstrapTokenFromGitConfig(foundryApiUrl: URL): Promise<string |
 }
 
 /**
- * Validates a Foundry token, trying each available source in priority order:
- * cached token → CLI token → git token (bootstrap only).
+ * Validates a Foundry token, preferring any token that is already valid before
+ * ever initiating an interactive refresh. If the cache is expired but the
+ * provided token is valid, the latter is used.
+ *
+ * Resolution order:
+ *   1. Any already-valid token (cached, then CLI).
+ *   2. Interactive refresh of an expired token (cached, then CLI).
+ *   3. Git token bootstrap (browser auth).
  */
 export async function validateFoundryToken(
   foundryApiUrl: URL,
   cliToken: string | undefined,
 ): Promise<string> {
   const cachedToken = loadCachedToken(foundryApiUrl.origin)
+  const candidates = [...new Set([cachedToken, cliToken].filter((t) => t !== undefined))]
 
-  if (cachedToken) {
-    const result = await tryRefreshToken(foundryApiUrl, cachedToken)
-    if (result) {
-      return result
+  // Valid-but-expired tokens, eligible for interactive refresh.
+  const refreshable: string[] = []
+
+  // 1. Prefer any already-valid token. isExpired() never opens a browser, so a
+  //    stale cached token can no longer trigger auth ahead of a valid CLI/env token.
+  for (const token of candidates) {
+    try {
+      if (await new TokenRefreshUtils(foundryApiUrl, token).isExpired()) {
+        refreshable.push(token)
+      } else {
+        return token
+      }
+    } catch (error: unknown) {
+      // Token is not valid for this environment
+      if (error instanceof InvalidAuthTokenError) {
+        console.error(error.message)
+        continue
+      }
+      throw error
     }
   }
 
-  if (cliToken && cliToken !== cachedToken) {
-    const result = await tryRefreshToken(foundryApiUrl, cliToken)
-    if (result) {
-      return result
+  // 2. Nothing is currently valid - interactively refresh an expired token.
+  for (const token of refreshable) {
+    try {
+      return await new TokenRefreshUtils(foundryApiUrl, token).forceRefreshToken()
+    } catch {
+      // Browser auth failed or timed out — try the next candidate.
     }
   }
 
+  // 3. Fall back to bootstrapping from the git token.
   const bootstrapped = await bootstrapTokenFromGitConfig(foundryApiUrl)
   if (bootstrapped) {
     return bootstrapped

--- a/src/utils/tokenRefreshUtils.ts
+++ b/src/utils/tokenRefreshUtils.ts
@@ -45,17 +45,13 @@ export class TokenRefreshUtils {
   }
 
   /**
-   * Checks if the token is expired and refreshes it via browser auth if needed.
-   * @returns Promise that resolves to the new token, or undefined if token is still valid
+   * Checks whether the current token is expired (or expiring within the minimum
+   * TTL) without initiating any interactive refresh.
+   * @returns true if the token is expired/expiring. Throws InvalidAuthTokenError
+   * if the token is not valid for this stack (e.g. signed by a different stack).
    */
-  async refreshTokenIfExpired(): Promise<string | undefined> {
-    const isExpired = await isTokenExpired(this.multipassApi, TokenRefreshUtils.MINIMUM_TOKEN_TTL)
-    if (!isExpired) {
-      // token is not expired
-      return
-    }
-
-    return this.forceRefreshToken()
+  async isExpired(): Promise<boolean> {
+    return isTokenExpired(this.multipassApi, TokenRefreshUtils.MINIMUM_TOKEN_TTL)
   }
 
   private generateSecret(): string {


### PR DESCRIPTION
## Before this PR
Provided token via `--foundry_token` flag or `FOUNDRY_TOKEN` environment variable not used over stale cached token.

## After this PR
Use provided token if cached token has expired.
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

