### PR TITLE
Preserve the HTTP status when the registry error body is not JSON

### DIFF
--- a/src/__tests__/preflightChecks.test.ts
+++ b/src/__tests__/preflightChecks.test.ts
@@ -111,11 +111,93 @@ describe('preflightChecks', () => {
       ;(global.fetch as any).mockResolvedValueOnce({
         ok: false,
         status: 500,
-        json: () => Promise.resolve({}),
+        text: () => Promise.resolve('{}'),
       })
       await expect(checkPackageAvailability(npmRegistry, foundryToken)).rejects.toThrow(
         PackageFetchError,
       )
+    })
+
+    it('should report the HTTP status when the registry returns an HTML error body', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      ;(global.fetch as any).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve('<html><body>Unauthorized</body></html>'),
+      })
+
+      const error = await checkPackageAvailability(npmRegistry, foundryToken).catch((e) => e)
+
+      expect(error).toBeInstanceOf(PackageFetchError)
+      expect((error as PackageFetchError).cause).toMatchObject({
+        message: expect.stringContaining('unexpected status 401'),
+      })
+      expect(consoleError).toHaveBeenCalledWith('<html><body>Unauthorized</body></html>')
+    })
+
+    it('should report the HTTP status when the registry returns an empty error body', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      ;(global.fetch as any).mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve(''),
+      })
+
+      const error = await checkPackageAvailability(npmRegistry, foundryToken).catch((e) => e)
+
+      expect(error).toBeInstanceOf(PackageFetchError)
+      expect((error as PackageFetchError).cause).toMatchObject({
+        message: expect.stringContaining('unexpected status 403'),
+      })
+      expect(consoleError).toHaveBeenCalledWith('<empty response body>')
+    })
+
+    it('should still log a JSON error body as structured output', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      ;(global.fetch as any).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('{"errorCode":"NOT_FOUND"}'),
+      })
+
+      const error = await checkPackageAvailability(npmRegistry, foundryToken).catch((e) => e)
+
+      expect(error).toBeInstanceOf(PackageFetchError)
+      expect((error as PackageFetchError).cause).toMatchObject({
+        message: expect.stringContaining('unexpected status 404'),
+      })
+      expect(consoleError).toHaveBeenCalledWith({ errorCode: 'NOT_FOUND' })
+    })
+
+    it('should truncate an oversized non-JSON error body', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      ;(global.fetch as any).mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        text: () => Promise.resolve('x'.repeat(5000)),
+      })
+
+      const error = await checkPackageAvailability(npmRegistry, foundryToken).catch((e) => e)
+
+      expect(error).toBeInstanceOf(PackageFetchError)
+      expect(consoleError).toHaveBeenCalledWith(`${'x'.repeat(500)}... (truncated)`)
+    })
+
+    it('should report the HTTP status when the error body cannot be read', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      ;(global.fetch as any).mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        text: () => Promise.reject(new Error('socket hang up')),
+      })
+
+      const error = await checkPackageAvailability(npmRegistry, foundryToken).catch((e) => e)
+
+      expect(error).toBeInstanceOf(PackageFetchError)
+      expect((error as PackageFetchError).cause).toMatchObject({
+        message: expect.stringContaining('unexpected status 503'),
+      })
+      expect(consoleError).toHaveBeenCalledWith('<unreadable response body>')
     })
   })
 

--- a/src/preflightChecks.ts
+++ b/src/preflightChecks.ts
@@ -106,6 +106,37 @@ export async function validateFoundryToken(
   throw new NoTokenAvailableError(foundryApiUrl.hostname)
 }
 
+const MAX_LOGGED_BODY_LENGTH = 500
+
+/**
+ * Reads an error response body without letting its content type mask the status.
+ *
+ * Artifact registries fronted by SSO or a corporate proxy answer with an HTML
+ * page or an empty body rather than JSON. `Response.json()` rejects on those,
+ * and because the rejection escapes the same `try` block that reports the
+ * status, the only actionable detail is replaced by a JSON syntax error.
+ */
+async function readErrorBody(resp: Response): Promise<unknown> {
+  let body: string
+  try {
+    body = await resp.text()
+  } catch {
+    return '<unreadable response body>'
+  }
+
+  if (body.trim() === '') {
+    return '<empty response body>'
+  }
+
+  try {
+    return JSON.parse(body)
+  } catch {
+    return body.length > MAX_LOGGED_BODY_LENGTH
+      ? `${body.slice(0, MAX_LOGGED_BODY_LENGTH)}... (truncated)`
+      : body
+  }
+}
+
 export async function checkPackageAvailability(
   npmRegistry: URL,
   foundryToken: string,
@@ -119,7 +150,7 @@ export async function checkPackageAvailability(
     }
     const resp = await fetch(packageMetadataUrl, requestOptions)
     if (!resp.ok) {
-      console.error(await resp.json())
+      console.error(await readErrorBody(resp))
 
       throw new Error(
         `Retrieving the Palantir MCP package responded with unexpected status ${resp.status}`,


### PR DESCRIPTION
## Problem

`checkPackageAvailability` logs the failure body with `resp.json()` inside the same `try` block that raises the status error:

```ts
const resp = await fetch(packageMetadataUrl, requestOptions)
if (!resp.ok) {
  console.error(await resp.json())

  throw new Error(
    `Retrieving the Palantir MCP package responded with unexpected status ${resp.status}`,
  )
}
} catch (error) {
  throw new PackageFetchError(error)
}
```

Artifact registries fronted by SSO or a corporate proxy answer failures with an HTML page or an empty body rather than JSON. `Response.json()` rejects on those, and the rejection escapes before the status error is ever constructed — so `PackageFetchError` is raised with a JSON syntax error as its cause and the HTTP status never reaches the user.

That status is the only actionable detail on a path whose message reads *"Please contact Foundry support for assistance."*

## Reproduction

Driving `checkPackageAvailability` against a real local HTTP server (no mocks), comparing current `develop` with this branch:

| Status | Registry response body | Before | After |
| --- | --- | --- | --- |
| 401 | JSON error | `unexpected status 401` | `unexpected status 401` |
| 401 | SSO HTML login page | `SyntaxError: Unexpected token '<'` | `unexpected status 401` |
| 502 | nginx HTML error page | `SyntaxError: Unexpected token '<'` | `unexpected status 502` |
| 403 | empty body | `SyntaxError: Unexpected end of JSON input` | `unexpected status 403` |
| 404 | `text/plain` | `SyntaxError: Unexpected token 'N'` | `unexpected status 404` |
| 500 | XML fault | `SyntaxError: Unexpected token '<'` | `unexpected status 500` |
| 401 | JSON content-type, HTML body (proxy interception) | `SyntaxError: Unexpected token '<'` | `unexpected status 401` |
| 503 | 20 KB HTML | `SyntaxError: Unexpected token '<'` | `unexpected status 503` |

The status is lost in 7 of 8 cases before the change and 0 of 8 after. The same behaviour reproduces against the published `palantir-mcp@0.14.0` bundle.

## Change

`readErrorBody` reads the body as text and parses JSON opportunistically, so the status always survives:

- valid JSON — logged as a structured object, unchanged from today
- non-JSON — logged as text, truncated at 500 characters so an SSO page does not flood stderr
- empty or unreadable — logged as an explicit placeholder

The success path is untouched and the thrown error type is unchanged; only the cause carried by `PackageFetchError` improves.

## Tests

Five regression tests cover HTML, empty, JSON, oversized and unreadable bodies. The one existing non-OK test mock moves from `json()` to `text()`.

`npm test` (61 passing), `npm run typecheck`, `npm run lint`, `npm run format:check` and `npm run build` all pass on Node 18 — the `engines` minimum — and on Node 24.
