### PR TITLE
Mirror the MCP server's exit status instead of always exiting 0

### DIFF
--- a/src/__tests__/spawn.test.ts
+++ b/src/__tests__/spawn.test.ts
@@ -7,6 +7,7 @@
 import { spawn } from 'child_process'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { McpLaunchError } from '../errors.js'
 import { spawnMcp } from '../spawn.js'
 
 vi.mock('child_process', () => ({
@@ -24,6 +25,7 @@ describe('spawn', () => {
     it('should spawn npx with correct arguments', () => {
       const mockChild = {
         kill: vi.fn(),
+        on: vi.fn(),
       }
       mockSpawn.mockReturnValue(mockChild)
 
@@ -52,6 +54,7 @@ describe('spawn', () => {
     it('should set correct environment variables', () => {
       const mockChild = {
         kill: vi.fn(),
+        on: vi.fn(),
       }
       mockSpawn.mockReturnValue(mockChild)
 
@@ -73,6 +76,7 @@ describe('spawn', () => {
     it('should preserve existing environment variables', () => {
       const mockChild = {
         kill: vi.fn(),
+        on: vi.fn(),
       }
       mockSpawn.mockReturnValue(mockChild)
 
@@ -98,6 +102,7 @@ describe('spawn', () => {
     it('should register SIGINT signal handler', () => {
       const mockChild = {
         kill: vi.fn(),
+        on: vi.fn(),
       }
       mockSpawn.mockReturnValue(mockChild)
 
@@ -117,6 +122,7 @@ describe('spawn', () => {
     it('should register SIGTERM signal handler', () => {
       const mockChild = {
         kill: vi.fn(),
+        on: vi.fn(),
       }
       mockSpawn.mockReturnValue(mockChild)
 
@@ -131,6 +137,77 @@ describe('spawn', () => {
       spawnMcp(options)
 
       expect(process.listenerCount('SIGTERM')).toBe(originalListenerCount + 1)
+    })
+  })
+
+  describe('child process outcome', () => {
+    const options = {
+      npmRegistry: new URL('https://example.com/npm/'),
+      foundryToken: 'test-token',
+      args: [],
+    }
+
+    function spawnWithHandlers() {
+      const handlers: Record<string, (...callbackArgs: any[]) => void> = {}
+      mockSpawn.mockReturnValue({
+        kill: vi.fn(),
+        on: vi.fn((event: string, handler: (...callbackArgs: any[]) => void) => {
+          handlers[event] = handler
+        }),
+      })
+      const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+      spawnMcp(options)
+      return { handlers, exit }
+    }
+
+    it('should exit with the code the MCP server exited with', () => {
+      const { handlers, exit } = spawnWithHandlers()
+
+      handlers.exit(42, null)
+
+      expect(exit).toHaveBeenCalledWith(42)
+      exit.mockRestore()
+    })
+
+    it('should exit 0 when the MCP server exits cleanly', () => {
+      const { handlers, exit } = spawnWithHandlers()
+
+      handlers.exit(0, null)
+
+      expect(exit).toHaveBeenCalledWith(0)
+      exit.mockRestore()
+    })
+
+    it('should report a signalled death as 128 + signal number', () => {
+      const { handlers, exit } = spawnWithHandlers()
+
+      handlers.exit(null, 'SIGTERM')
+
+      expect(exit).toHaveBeenCalledWith(143)
+      exit.mockRestore()
+    })
+
+    it('should exit non-zero when the child terminates without a code or signal', () => {
+      const { handlers, exit } = spawnWithHandlers()
+
+      handlers.exit(null, null)
+
+      expect(exit).toHaveBeenCalledWith(1)
+      exit.mockRestore()
+    })
+
+    it('should report a failed spawn instead of throwing an unhandled error', () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const { handlers, exit } = spawnWithHandlers()
+
+      const cause = Object.assign(new Error('spawn npx ENOENT'), { code: 'ENOENT' })
+      handlers.error(cause)
+
+      expect(consoleError).toHaveBeenCalledWith(expect.any(McpLaunchError))
+      expect(consoleError.mock.calls[0][0].cause).toBe(cause)
+      expect(exit).toHaveBeenCalledWith(1)
+      exit.mockRestore()
+      consoleError.mockRestore()
     })
   })
 })

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -76,6 +76,19 @@ export class NoTokenAvailableError extends McpError {
   }
 }
 
+export class McpLaunchError extends McpError {
+  constructor(cause: unknown) {
+    super(
+      `Unable to start the Palantir MCP server. Please ensure:
+- Node.js 18 or higher and npm are installed and available on your PATH.
+- If you launch this server from an MCP client, that client may not inherit your
+  shell PATH. Configure it with an absolute path to node/npx if npx cannot be found.`,
+      cause,
+    )
+    this.name = 'McpLaunchError'
+  }
+}
+
 export class PackageFetchError extends McpError {
   constructor(cause: unknown) {
     super(

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -5,11 +5,26 @@
  */
 
 import { spawn } from 'child_process'
+import { constants } from 'os'
+import { McpLaunchError } from './errors.js'
 
 export interface SpawnOptions {
   npmRegistry: URL
   foundryToken: string
   args: string[]
+}
+
+/**
+ * Translates the child's termination into an exit code for this process. A
+ * signal death is reported as 128 + signal number, matching shell convention.
+ */
+function exitCodeFor(code: number | null, signal: NodeJS.Signals | null): number {
+  if (code !== null) {
+    return code
+  }
+
+  const signalNumber = signal === null ? undefined : constants.signals[signal]
+  return signalNumber === undefined ? 1 : 128 + signalNumber
 }
 
 export function spawnMcp({ npmRegistry, foundryToken, args }: SpawnOptions): void {
@@ -24,6 +39,18 @@ export function spawnMcp({ npmRegistry, foundryToken, args }: SpawnOptions): voi
       NPM_CONFIG_REGISTRY: npmRegistry.toString(),
       [authTokenEnvVar]: foundryToken,
     },
+  })
+
+  // An MCP client treats this process as the server, so its exit status has to
+  // mirror the child's. Without this the wrapper reports success even when the
+  // server crashed, and a failed spawn surfaces as an unhandled 'error' event.
+  child.on('error', (error) => {
+    console.error(new McpLaunchError(error))
+    process.exit(1)
+  })
+
+  child.on('exit', (code, signal) => {
+    process.exit(exitCodeFor(code, signal))
   })
 
   process.on('SIGINT', () => {


### PR DESCRIPTION
## Problem

`spawnMcp` starts `@palantir/mcp` and then never observes it. The only listeners registered are `SIGINT` and `SIGTERM` forwarders, so nothing reacts to the child exiting or failing to start.

Two consequences, both on the path an MCP client depends on:

**1. The exit status is always 0.** An MCP client launches this wrapper *as* the server process, so this process's exit status is the server's exit status. Today a crashed server is indistinguishable from a clean shutdown.

**2. A failed spawn throws an unhandled `'error'` event.** `ChildProcess` emits `'error'` when the binary cannot be started; with no listener, Node rethrows it. An `npx` that is not on `PATH` — common when a client launches the server without inheriting the user's shell environment — produces an internal stack trace rather than one of this CLI's actionable messages.

## Reproduction

Running the real bundle with a stub `npx` on `PATH`, then with `npx` absent:

| Scenario | Before | After |
| --- | --- | --- |
| server exits `42` | parent exits **`0`** | parent exits `42` |
| server killed by `SIGTERM` | parent exits **`0`** | parent exits `143` |
| server exits `0` | parent exits `0` | parent exits `0` |
| `npx` not on `PATH` | `Error: spawn npx ENOENT` + `Unhandled 'error' event` stack | `McpLaunchError` with PATH guidance |

Before this change, all three termination outcomes are reported identically as success.

## Change

- `child.on('exit')` forwards the child's outcome: its exit code, or `128 + signal number` when it is signalled, matching shell convention (`143` for `SIGTERM`, `130` for `SIGINT`).
- `child.on('error')` reports launch failures as a new `McpLaunchError`, which keeps the original error as its `cause` and follows the actionable style of `NetworkError` and `NoTokenAvailableError`.

The success path is unchanged — a server that exits `0` still exits `0`.

## Tests

Five tests cover exit code forwarding, clean exit, signalled death, a termination with neither code nor signal, and a failed spawn. The existing `spawnMcp` mocks gain an `on` stub.

`npm test` (61 passing), `npm run typecheck`, `npm run lint`, `npm run format:check` and `npm run build` pass on Node 18 — the `engines` minimum — and on Node 24.

## Note

`src/spawn.ts` is also touched by #33. The two changes are in different hunks (that PR edits the `spawn()` argument list; this one appends listeners after it), so they should not conflict, but happy to rebase on whichever lands first.
